### PR TITLE
Replaced deprecated pi-wifi.connect call with pi-wifi.connectTo

### DIFF
--- a/script.js
+++ b/script.js
@@ -280,7 +280,14 @@ function getPassword(ssid){
 }
 
 function ssidConnect(ssid, password){
-    piWifi.connect(ssid, password, (err)=>{
+    var networkDetails = {
+        ssid: ssid,
+    }
+    // Add the password if one was supplied.
+    if (password != ""){
+        networkDetails.password = password
+    }
+    piWifi.connectTo(networkDetails, (err)=>{
         if (!err){
             lblSSID.value = ssid;
             showPage("Home");


### PR DESCRIPTION
This code change removes the use of the deprecated pi-wifi.connect function with pi-wifi.connectTo and should also allow connectivity to open networks that do not use a password.